### PR TITLE
FixEmptyLookupException: fixed issue when lookup field in formula is …

### DIFF
--- a/activate_editor.js
+++ b/activate_editor.js
@@ -713,6 +713,9 @@ function LoadFieldValuesPreview(e)
 			var oCurrentRecordPart = oRecord;
 			for (var p = 0; p < oFieldParts.length; p++)
 			{
+				if (!oCurrentRecordPart) {
+					break;
+				}
 				oCurrentRecordPart = oCurrentRecordPart[oFieldParts[p]];
 			}
 			var $trField = editorJQuery(this).parent();


### PR DESCRIPTION
Fixed the issue when lookup field is empty on a record.
Steps to reproduce:
1. Create a formula field of text type on "Lead" to "Account".
2. In this formula field, create a reference to Account.Name and to LastName of Lead. Save formula.
3. Create a lead record, leave "Account" field empty.
4. Go to Editing the formula field.
5. Click "Load Field Details".
6. Set lead Id to "Enter Record Id".
7. Click "Load Record Values".

Expected behaviour:
Account.Name, LastName is populated.

Actual behaviour:
None of Account.Name, LastName is populated.